### PR TITLE
Adopt work dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To perform the setup, run:
 The setup contains the necessary instruction to initialise the submodule.
 
 ### Conversion
-To start the conversion, place the **epub file** and the **DOI deposit** in the `./XML-last/` folder. Finally, run:
+To start the conversion, place the **epub file** and the **DOI deposit** in the _obp-gen-xml_ folder. Finally, run:
 
 `bash run`
 
@@ -22,9 +22,10 @@ To start the conversion, place the **epub file** and the **DOI deposit** in the 
 
 `bash clean [-y]`
 
-would remove temporary files from `./XML-last/` (untracked files and folders). The script asks for the user's confirmation before removing the files, but if you are running this as part of a script you might want to use the`-y` flag to bypass the confirmation. 
+would remove temporary files (untracked files and folders) from the _obp-gen-xml_ folder. The script asks for the user's confirmation before removing the files, but if you are running this as part of a script you might want to use the`-y` flag to bypass the confirmation. 
 
 ## DEV
+### tailor_book_transform.py
 This suite of scripts works as expected, but the introduction of `tailor_book_transform.py` is to be regarded as a _temporary patch_.
 
 The stylesheet `Transform-to-XML-book.xsl` merges together XML files of the book sections. This is performed by tentative _includes_ of possible filenames hardcoded in the spreadsheet. All this works smoothly with the XML parser embedded in Oxygen, but the (apparently less tolerant) XML parser that `saxonb-xslt` uses fails at the first occurrence of a missing file.
@@ -32,3 +33,6 @@ The stylesheet `Transform-to-XML-book.xsl` merges together XML files of the book
 `tailor_book_transform.py` creates a temporary and simplified version of `Transform-to-XML-book.xsl` which lists only the successful includes.
 
 There are a number of possible solutions, including (a) forcing `saxonb-xslt` to use a different XML parser and (b) re-write the `Transform-to-XML-book.xsl` to make its list of includes more precise.
+
+### run
+The way the _run_ script picks up files to process is not very precise (currently, via wildcards/asterisks). We might want to improve this in the future; solutions include (a) defining naming conventions for input files across all our scripts and (b) make bash to accept filenames as input arguments.

--- a/clean
+++ b/clean
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 
@@ -16,7 +16,7 @@ function clean {
     git clean -df
 }
 
-cd $(dirname $0)/XML-last
+cd $(dirname $0)
 
 if [ "$FORCE_YES" = 1 ]
 then
@@ -31,5 +31,3 @@ else
 	clean
     fi
 fi
-
-

--- a/run
+++ b/run
@@ -1,31 +1,60 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
+
+cleanup () {
+    local rv=$?
+    rm -rf -- "$work_dir"
+    exit $rv
+}
+
+trap cleanup EXIT
+
+convert () {
+    cd $work_dir
+
+    echo "running XML-before-transformation.py"
+    python2.7 XML-before-transformation.py
+
+    echo "running Transform-to-XML-section.xsl"
+    saxonb-xslt -s:Transform-to-XML-section.xsl \
+		-xsl:Transform-to-XML-section.xsl \
+		-o:Transform-to-XML-section.xsl \
+		-ext:on
+
+    echo "creating Transform-to-XML-section_tailored.xsl"
+    python3 tailor_book_transform.py
+
+    echo "running Transform-to-XML-section_tailored.xsl"
+    saxonb-xslt -s:Transform-to-XML-book_tailored.xsl \
+		-xsl:Transform-to-XML-book_tailored.xsl \
+		-xi:on \
+		-ext:on
+
+    echo "running XML-after-transformation.py"
+    python2.7 XML-after-transformation.py
+
+    # Create a zip archive of the XML edition
+    find . -name '*.zip' | while read file; do
+	filename=$(basename -- ${file%.*})
+	zip -rq ${filename}.xml.zip XML-edition/
+
+	echo "created ./${filename}.xml.zip"
+    done
+}
+
+work_dir=$(mktemp -d -t obp-gen-xml-XXXXXX)
+
+echo "Copy relevant files to work directory"
+# We need to revise the way how these files get picked up
+cp *.epub $work_dir
+cp *.xml $work_dir
+cp tailor_book_transform.py $work_dir
+cp -r XML-last/. $work_dir
 
 cd $(dirname $0)
 source .venv/bin/activate
 
-cd $(dirname $0)/XML-last
+(convert)
 
-echo "running XML-before-transformation.py"
-python2.7 XML-before-transformation.py
-
-echo "running Transform-to-XML-section.xsl"
-saxonb-xslt -s:Transform-to-XML-section.xsl -xsl:Transform-to-XML-section.xsl -o:Transform-to-XML-section.xsl -ext:on
-
-echo "creating Transform-to-XML-section_tailored.xsl"
-python3 ../tailor_book_transform.py
-
-echo "running Transform-to-XML-section_tailored.xsl"
-saxonb-xslt -s:Transform-to-XML-book_tailored.xsl -xsl:Transform-to-XML-book_tailored.xsl -xi:on -ext:on
-
-echo "running XML-after-transformation.py"
-python2.7 XML-after-transformation.py
-
-# Create a zip archive of the XML edition
-find . -name '*.zip' | while read file; do
-    filename=$(basename -- ${file%.*})
-    zip -rq ${filename}.xml.zip XML-edition/
-
-    echo "created ./XML-last/${filename}.xml.zip"
-done
+cp $work_dir/*.xml.zip .

--- a/tailor_book_transform.py
+++ b/tailor_book_transform.py
@@ -1,24 +1,13 @@
 from bs4 import BeautifulSoup
 import os
 
-in_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                       'XML-last',
-                       'Transform-to-XML-book.xsl')
-out_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                       'XML-last',
-                        'Transform-to-XML-book_tailored.xsl')
-
-with open(in_path, 'r') as input:
+with open('Transform-to-XML-book.xsl', 'r') as input:
     soup = BeautifulSoup(input, 'html.parser')
 
     includes = soup.find_all('xi:include')
     for include in includes:
-        file_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                                 'XML-last',
-                                 include.get('href'))
-
-        if not os.path.isfile(file_path):
+        if not os.path.isfile(include.get('href')):
             include.extract()
 
-    with open(out_path, 'w') as output:
+    with open('Transform-to-XML-book_tailored.xsl', 'w') as output:
         output.write(soup.prettify(formatter='minimal'))


### PR DESCRIPTION
This branch includes commits to make _obp-gen-xml_ work similarly to the (better designed) _obp-extract-cit_. In particular:
 -  Input files are expected to be in the root folder of the project (consistency with _obp-extract-cit_);
 -  The conversion happens in a temporary directory which gets deleted as the process ends (it doesn't clutter the ./XML-last/ folder; consistency with _obp-extract-cit_);
 -  The output is copied to the project root folder (consistency with _obp-extract-cit_).